### PR TITLE
Adding partial form field blocks to config file

### DIFF
--- a/projects/plugins/jetpack/wpml-config.xml
+++ b/projects/plugins/jetpack/wpml-config.xml
@@ -7,4 +7,40 @@
 		</key>
 		<key name="highlander_comment_form_prompt" />
 	</admin-texts>
+	<gutenberg-blocks>
+    <gutenberg-block type="jetpack/field-name" translate="1">
+      <key name="label">
+      </key>
+    </gutenberg-block>
+    <gutenberg-block type="jetpack/field-email" translate="1">
+      <key name="label">
+      </key>
+    </gutenberg-block>
+    <gutenberg-block type="jetpack/field-telephone" translate="1">
+      <key name="label">
+      </key>
+    </gutenberg-block>
+    <gutenberg-block type="jetpack/field-textarea" translate="1">
+      <key name="label">
+      </key>
+    </gutenberg-block>
+    <gutenberg-block type="jetpack/field-radio" translate="1">
+      <key name="label"></key>
+      <key name="options">
+        <key name="*"></key>
+      </key>
+    </gutenberg-block>
+    <gutenberg-block type="jetpack/field-select" translate="1">
+      <key name="label"></key>
+      <key name="options">
+        <key name="*"></key>
+      </key>
+    </gutenberg-block>
+    <gutenberg-block type="jetpack/button" translate="1">
+      <key name="text"></key>
+    </gutenberg-block>
+    <gutenberg-block type="jetpack/field-consent" translate="1">
+      <key name="implicitConsentMessage"></key>
+    </gutenberg-block>
+  </gutenberg-blocks>
 </wpml-config>


### PR DESCRIPTION
To demonstrate how to add Gutenberg Blocks to your WPML file, I've added a selection of blocks and set them as Translateable via WPML's Advanced Translation Editor. 

These blocks are related to form fields and include:

"jetpack/field-name"
"jetpack/field-email"
"jetpack/field-telephone"
"jetpack/field-textarea"
"jetpack/field-radio"
"jetpack/field-select"
"jetpack/button"
"jetpack/field-consent"

Full instructions for registering Gutenberg Blocks in the WPML config file can be found here: https://wpml.org/documentation/support/language-configuration-files/#gutenberg-blocks

<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to projects/plugins/jetpack/to-test.md in a new commit as part of your PR. -->

Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* Adding various form field blocks to the WPML config file, allowing them to be translatable via WPML's Advanced Translation Editor

#### Jetpack product discussion
<!-- If you're an Automattician, include a shortlink to the p2 discussion with Jetpack Product here. -->
<!-- Make sure any changes to existing products have been discussed and agreed upon -->

#### Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Go to '..'
*
